### PR TITLE
Make struct Style initializer public.

### DIFF
--- a/RemainingCountIndicator/RemainingCountIndicator.swift
+++ b/RemainingCountIndicator/RemainingCountIndicator.swift
@@ -47,7 +47,7 @@ public final class RemainigCountIndicator: UIView {
 
         let lineWidth: CGFloat
 
-        init(
+        public init(
             progressNormalColor: UIColor = .init(white: 0, alpha: 0.8),
             progressWarningColor: UIColor = .orange,
             progressErrorColor: UIColor = .red,


### PR DESCRIPTION
Cocoapodsでインストールした時、`RemainigCountIndicator.Style`のinitializerがpublicでないためREADME通りに初期化できない問題を修正しました。

`init`がpublicでない場合に次のエラーが発生します。
![Screen Shot 2019-10-23 at 0 32 19](https://user-images.githubusercontent.com/154327/67303003-bc6ae900-f52c-11e9-9850-a211649e122e.png)
